### PR TITLE
Open source NTR CFW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BootNTR
 
-Boots NTR CFW.
+Boots NTR C(losed source)FW.
 
 
 # Latest Build


### PR DESCRIPTION
It would help advance the 3DS hacking scene, and NTR CFW.
There's no reason not to, so why not? @44670 
BootNTR is open source however the payload (bin) is not. It's closed source.